### PR TITLE
promote: add promote functionality to regular and continuous publish

### DIFF
--- a/vars/runStackContinuousPipeline.groovy
+++ b/vars/runStackContinuousPipeline.groovy
@@ -18,6 +18,9 @@ def call() {
         environment {
             DOCKER = credentials('dockerhub-upboundci')
             CROSSPLANE_CLI_RELEASE = 'master'
+            // The promote channel is a tag which is used as a release channel. It's
+            // updated whenever a new artifact is ready for that channel.
+            PROMOTE_CHANNEL = 'master'
         }
 
         stages {
@@ -27,7 +30,7 @@ def call() {
                     sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
                 }
             }
-            stage('Promote Release') {
+            stage('Publish Release') {
 
                 steps {
                     // The build step turns this into a "dirty" environment from the perspective of `git describe`,
@@ -36,6 +39,18 @@ def call() {
                     sh """STACK_VERSION=\$( git describe --tags --dirty --always )
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
+                    """
+                }
+            }
+
+            stage('Promote Release to Channel') {
+
+                steps {
+                    // Ideally we wouldn't be rebuilding and repushing (a true promote would use the same artifact),
+                    // but this is easier to implement.
+
+                    sh """STACK_VERSION=${PROMOTE_CHANNEL} ./bin/kubectl-crossplane-stack-build
+                          STACK_VERSION=${PROMOTE_CHANNEL} ./bin/kubectl-crossplane-stack-publish
                     """
                 }
             }


### PR DESCRIPTION
Related to crossplane/crossplane#1235

### Overview

We want to update release channel tags when we publish for a regular
release or for a continuous release. This adds a simple and dumb
implementation.

Originally I was working on a more generalized, decoupled promote job which does a docker pull, tag, and push, but that was taking too much time, so I've added an implementation of the simpler approach instead. The simple approach is to just build and publish everything twice when we're building and publishing it.

### Testing

I've tested this [in this job](https://jenkinsci.upbound.io/job/crossplane/job/sample-stack-wordpress/job/publish/job/promote-images/1/console). You can see the published images in this [private crossplane dockerhub repository](https://hub.docker.com/repository/docker/crossplane/test-sample-wordpress-stack-channels).

### Other work

Once this is merged, we will want to:

* [ ] Publish the appropriate images to `alpha` and `master` for all template stacks
* [ ] Delete the `latest` tags for all of the template stack docker repositories

I'm also planning on writing a document explaining our tagging conventions.