### PR TITLE
publish: sync images on publish

### DIFF
--- a/vars/runStackContinuousPipeline.groovy
+++ b/vars/runStackContinuousPipeline.groovy
@@ -54,6 +54,15 @@ def call() {
                     """
                 }
             }
+
+            stage('Sync images') {
+
+                steps {
+                    // We don't need to wait, and waiting takes up an executor slot
+                    build job: '/crossplane/sync-stacks', wait: false
+                }
+
+            }
         }
 
         post {

--- a/vars/runStackPublishPipeline.groovy
+++ b/vars/runStackPublishPipeline.groovy
@@ -52,6 +52,15 @@ def call() {
                     """
                 }
             }
+
+            stage('Sync images') {
+
+                steps {
+                    // We don't need to wait, and waiting takes up an executor slot
+                    build job: '/crossplane/sync-stacks', wait: false
+                }
+
+            }
         }
 
         post {


### PR DESCRIPTION
We want to sync our stacks whenever we publish a new image for a stack.

## Testing

This snippet has been tested [in this Jenkins job execution](https://jenkinsci.upbound.io/job/crossplane/job/sample-stack-wordpress/job/continuous-publish/job/master/6/console).