### PR TITLE
Template stacks: Continuous auto versioning

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -52,6 +52,13 @@ Typically we copy from an existing item. The general steps are:
 * Once the folder is created, go into each of the jobs that was created,
   and update the Git url to point to your repository.
 
+### What about docker credentials?
+
+The shared Jenkins code takes care of that for us. It loads the docker
+credentials early in its configuration, and then does a `docker login`
+before docker operations, using environment variables set by Jenkins
+when the docker credentials are loaded.
+
 ### How do I cut a release?
 
 Cutting a release involves: tagging a commit for a release; building and

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -16,8 +16,11 @@ Each of them has a different purpose.
 
 ### What repository can I use as a reference?
 
-Try out the [sample-stack-wordpress repo](https://github.com/crossplane/sample-stack-wordpress).
-Take a look at the `Jenkinsfile.*` files.
+Try out the [app-wordpress
+repo](https://github.com/crossplane/app-wordpress).
+Take a look at the `Jenkinsfile.*` files. To see the Jenkins jobs that
+result, take a look at the [app-wordpress Jenkins folder on the Upbound
+Jenkins](https://jenkinsci.upbound.io/job/crossplane/job/app-wordpress/).
 
 ### What else is needed other than Jenkinsfiles?
 
@@ -45,27 +48,30 @@ Typically we copy from an existing item. The general steps are:
 * At the top, enter in the name of your repository, such as
   `stack-my-app`.
 * At the bottom, in the `Copy from` field, enter in an existing stack
-  folder, such as `sample-stack-wordpress`.
+  folder, such as `app-wordpress`.
 * Once the folder is created, go into each of the jobs that was created,
   and update the Git url to point to your repository.
 
 ### How do I cut a release?
 
-Cutting a release involves: (potentially) cutting a new release branch;
-tagging a commit for a release; building and publishing from the tagged
-commit. Using the jobs, the steps are:
+Cutting a release involves: tagging a commit for a release; building and
+publishing from the tagged commit. Using the jobs, the steps are:
 
-1. Using the job `branch-create`, create a release branch if one doesn't
-   exist. We use the convention `release-MAJOR.MINOR`. For example:
-   `release-0.1`. If a branch already exists for the release version
-   prefix, update the branch with the new changes instead of creating a
-   new one.
-2. Using the job `tag`, tag the commit you want to release, with the
-   release tag. The tag should be in the form `vMAJOR.MINOR.PATCH`. For
-   example: `v0.1.0`.
-3. Using the job `publish`, build and publish the tag you want to
+1. Using the job `tag`, tag the `master` branch with the release tag.
+   The tag should be in the form `vMAJOR.MINOR.PATCH`. For example:
+   `v0.1.0`.
+2. Using the job `publish`, build and publish the tag you want to
    release. You should be able to do this using the same tag as what you
    used in the tagging step.
+
+**Release branches**: We do not use release branches for a release in
+most scenarios. We originally did, and realized we were not getting any
+benefit from them, so we removed them from the process to simplify
+things. If we end up needing them in the future, we can change the
+process to be more robust. Release branches would become useful if we
+needed to develop and maintain multiple distinct versions at the same
+time. They're also useful for doing a patch release of a version which
+was not the most recently released version.
 
 **NOTE - KNOWN ISSUE**: You may need to run a job multiple times when a
 new branch is recognized by Jenkins. We are currently using multibranch
@@ -75,6 +81,27 @@ what parameters are needed to run the job successfully, so it doesn't
 let you specify any parameters, and the job may fail. After the first
 execution, Jenkins will let you specify parameters, and you can run it
 again with parameters. It isn't ideal, but that's the current pattern.
+
+#### Patch Releases
+
+A patch release is a release with bug fixes, where the patch version is
+incremented. For example, a patch release after `v0.1.0` would be
+`v0.1.1`.
+
+If the patch release is a patch of the most recently released version,
+the process is the same as a normal release.
+
+If the patch is for a version before the most recent release, a release
+branch will be needed.
+
+To create a release branch, use the job `branch-create`, and use the
+tag that we want to create a patch release from. For example, if we
+previously released `v0.1.0`, and we want to cut the patch release
+`v0.1.1`, create the branch from the `v0.1.0` tag. We use the convention
+`release-MAJOR.MINOR` for naming release branches. For example:
+`release-0.1`. If a branch already exists for the release version
+prefix, update the branch with the new changes instead of creating a new
+one.
 
 ### How do I get my merges to master automatically released?
 

--- a/vars/runStackContinuousPipeline.groovy
+++ b/vars/runStackContinuousPipeline.groovy
@@ -34,6 +34,8 @@ def call() {
             stage('Publish Release') {
 
                 steps {
+                    sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+
                     // The build step turns this into a "dirty" environment from the perspective of `git describe`,
                     // so we set the version once at the beginning and use it for both the build and publish steps.
 
@@ -63,6 +65,8 @@ def call() {
             stage('Promote Release to Channel') {
 
                 steps {
+                    sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+
                     // Ideally we wouldn't be rebuilding and repushing (a true promote would use the same artifact),
                     // but this is easier to implement.
 

--- a/vars/runStackContinuousPipeline.groovy
+++ b/vars/runStackContinuousPipeline.groovy
@@ -28,6 +28,7 @@ def call() {
                 steps {
                     sh 'mkdir bin'
                     sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+                    sh "curl -sL -o bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.0.0/src/semver && chmod +x bin/semver"
                 }
             }
             stage('Publish Release') {
@@ -36,7 +37,23 @@ def call() {
                     // The build step turns this into a "dirty" environment from the perspective of `git describe`,
                     // so we set the version once at the beginning and use it for both the build and publish steps.
 
-                    sh """STACK_VERSION=\$( git describe --tags --dirty --always )
+                    // The lines which calculate the stack version are a bit complicated, so here are some examples
+                    // of the final version output for different scenarios.
+                    //
+                    // * No tags, one commit in the repository: v0.1.0-rc-1-gdeadbee
+                    // * No tags, ten commits in the repository: v0.1.0-rc-10-gdeadbee
+                    // * Most recent tag v0.1.0, target commit is same as tag: v0.2.0-rc-0-gdeadbee
+                    // * Most recent tag v0.1.0, target commit is 2 commits after the tag: v0.2.0-rc-2-gdeadbee
+                    // * Most recent tag v0.1.0-rc, target commit is 2 commits after the tag: v0.2.0-rc-2-gdeadbee
+                    sh """STACK_VERSION=\$( git describe --tags --long || echo "v0.0.0-rc-\$( git log --oneline | wc -l | xargs echo )-g\$( git rev-parse --short=7 HEAD )" )
+                          STACK_PREREL=\$( bin/semver get prerel \${STACK_VERSION} )
+
+                          # In the case that our most recent tag was something like v0.1.0, our `git describe` output
+                          # will look like 'v0.1.0-2-gdeadbee'. This makes our prerelease segment look more like
+                          # 'rc-2-gdeadbee', instead of '2-gdeadbee'.
+                          STACK_PREREL=\$( echo \${STACK_PREREL} | sed -e 's/\\(^[0-9]\\)/rc-\\1/' )
+
+                          STACK_VERSION="v\$( bin/semver bump minor \${STACK_VERSION} )-\${STACK_PREREL}"
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
                     """

--- a/vars/runStackPublishPipeline.groovy
+++ b/vars/runStackPublishPipeline.groovy
@@ -38,6 +38,8 @@ def call() {
             stage('Publish Release') {
 
                 steps {
+                    sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+
                     sh """
                           STACK_VERSION=${params.version}
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
@@ -49,6 +51,8 @@ def call() {
             stage('Promote Release to Channel') {
 
                 steps {
+                    sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+
                     // Ideally we wouldn't be rebuilding and repushing (a true promote would use the same artifact),
                     // but this is easier to implement.
 

--- a/vars/runStackPublishPipeline.groovy
+++ b/vars/runStackPublishPipeline.groovy
@@ -4,7 +4,7 @@ def call() {
         agent { label 'upbound-gce' }
 
         parameters {
-            string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+            string(name: 'version', description: 'Required. The version you are publishing. For example: v0.4.0.')
         }
 
         options {
@@ -21,20 +21,25 @@ def call() {
         }
 
         stages {
+            stage('Check Required Parameters') {
+                steps {
+                    sh "test -n '${params.version}' || ( echo 'ERROR: The version is required. Please specify a version to release.' >&2 && exit 1 )"
+                    sh "( echo '${params.version}' | grep -q -E '^v' - ) || ( echo 'ERROR: The version needs to start with a \"v\". Example: \"v0.1.0\".' >&2 && exit 1 )"
+                }
+            }
+
             stage('Prepare') {
                 steps {
                     sh 'mkdir bin'
                     sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
                 }
             }
+
             stage('Publish Release') {
 
                 steps {
-                    // The build step turns this into a "dirty" environment from the perspective of `git describe`,
-                    // so we set the version once at the beginning and use it for both the build and publish steps.
-
-                    sh """STACK_VERSION=${params.version}
-                          STACK_VERSION=\${STACK_VERSION:-\$( git describe --tags --dirty --always )}
+                    sh """
+                          STACK_VERSION=${params.version}
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
                     """


### PR DESCRIPTION
## Overview

When we build an artifact from our continuous build job which runs
against changes to `master`, we want to be able to consistently have a
prerelease semantic version, which follows the semantic version ordering
contract. To do this, we can generate and manipulate the version which
is used for the artifact. We use the most recent tag in the current
branch as a base.

As part of this change, we also now expect the publish pipeline to
**not** generate a version; an operator must specify the parameter by
hand.

## Testing

* I've tested the different cases of tag generation locally by hand
* Here's a [test run of the parameter-checking logic for publish](https://jenkinsci.upbound.io/job/upbound/job/suskin-test/job/master/9/console)
* Here's a [test run of the tag-generation logic for the at-tag case](https://jenkinsci.upbound.io/job/crossplane/job/app-wordpress/job/continuous-publish/job/master/13/console)