### PR TITLE
Tag rc builds with valid semver

### DIFF
--- a/vars/runStackContinuousPipeline.groovy
+++ b/vars/runStackContinuousPipeline.groovy
@@ -42,18 +42,18 @@ def call() {
                     // The lines which calculate the stack version are a bit complicated, so here are some examples
                     // of the final version output for different scenarios.
                     //
-                    // * No tags, one commit in the repository: v0.1.0-rc-1-gdeadbee
-                    // * No tags, ten commits in the repository: v0.1.0-rc-10-gdeadbee
-                    // * Most recent tag v0.1.0, target commit is same as tag: v0.2.0-rc-0-gdeadbee
-                    // * Most recent tag v0.1.0, target commit is 2 commits after the tag: v0.2.0-rc-2-gdeadbee
-                    // * Most recent tag v0.1.0-rc, target commit is 2 commits after the tag: v0.2.0-rc-2-gdeadbee
-                    sh """STACK_VERSION=\$( git describe --tags --long || echo "v0.0.0-rc-\$( git log --oneline | wc -l | xargs echo )-g\$( git rev-parse --short=7 HEAD )" )
+                    // * No tags, one commit in the repository: v0.1.0-rc.1.gdeadbee
+                    // * No tags, ten commits in the repository: v0.1.0-rc.10.gdeadbee
+                    // * Most recent tag v0.1.0, target commit is same as tag: v0.2.0-rc.0.gdeadbee
+                    // * Most recent tag v0.1.0, target commit is 2 commits after the tag: v0.2.0-rc.2.gdeadbee
+                    // * Most recent tag v0.1.0-rc, target commit is 2 commits after the tag: v0.2.0-rc.2.gdeadbee
+                    sh """STACK_VERSION=\$( git describe --tags --long || echo "v0.0.0-rc.\$( git log --oneline | wc -l | xargs echo ).g\$( git rev-parse --short=7 HEAD )" )
                           STACK_PREREL=\$( bin/semver get prerel \${STACK_VERSION} )
 
                           # In the case that our most recent tag was something like v0.1.0, our `git describe` output
                           # will look like 'v0.1.0-2-gdeadbee'. This makes our prerelease segment look more like
-                          # 'rc-2-gdeadbee', instead of '2-gdeadbee'.
-                          STACK_PREREL=\$( echo \${STACK_PREREL} | sed -e 's/\\(^[0-9]\\)/rc-\\1/' )
+                          # 'rc.2.gdeadbee', instead of '2-gdeadbee'.
+                          STACK_PREREL=\$( echo \${STACK_PREREL} | sed -e 's/\\(^[0-9]\\)/rc.\\1/' | sed -e 's/-g/.g/' )
 
                           STACK_VERSION="v\$( bin/semver bump minor \${STACK_VERSION} )-\${STACK_PREREL}"
                           STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build


### PR DESCRIPTION
Updates continuous pipeline with valid semver tagging per https://semver.org/#spec-item-9

This has been tested by copying the script to `stack-azure-sample` and running on `HEAD` of `master`, then running on a commit (`d97b85714d3f29a2857791d0e3c572a9449315af`) that existed before the first tag. The output was as follows:

For `HEAD`: `v0.4.0-rc.10.g0a4a595`

For old commit: `v0.1.0-rc.5.gd97b857`

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>